### PR TITLE
Make queryKey of HistoryOptions optional

### DIFF
--- a/history.d.ts
+++ b/history.d.ts
@@ -28,7 +28,7 @@ declare module otherHistory {
 
 	interface HistoryOptions {
 		getUserConfirmation?(message: string, callback: (confirmed: boolean) => void): void;
-		queryKey: boolean;
+		queryKey?: boolean;
 	}
 
 	interface BeforeUnload {


### PR DESCRIPTION
queryKey should not have to be required, as demonstrated here: https://github.com/mjackson/history
